### PR TITLE
chore: use correct framework

### DIFF
--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -30,13 +30,13 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Create Output Directory
-        run: mkdir -p '${{github.workspace}}/RTWLib_Tests/bin/Debug/netcoreapp8.0/resources'
+        run: mkdir -p '${{github.workspace}}/RTWLib_Tests/bin/Debug/net8.0/resources'
 
       - name: Copy Resources
-        run: cp -r ./RTWLib_Tests/resources/. ${{ github.workspace }}/RTWLib_Tests/bin/Debug/netcoreapp8.0/resources/
+        run: cp -r ./RTWLib_Tests/resources/. ${{ github.workspace }}/RTWLib_Tests/bin/Debug/net8.0/resources/
 
       - name: List build output
-        run: ls -R '${{github.workspace}}/RTWLib_Tests/bin/Debug/netcoreapp8.0'
+        run: ls -R '${{github.workspace}}/RTWLib_Tests/bin/Debug/net8.0'
 
       - name: Log files
         run: ls

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -27,13 +27,13 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Create Output Directory
-        run: mkdir -p '${{github.workspace}}/RTWLib_Tests/bin/Debug/netcoreapp8.0/resources'
+        run: mkdir -p '${{github.workspace}}/RTWLib_Tests/bin/Debug/net8.0/resources'
 
       - name: Copy Resources
-        run: cp -r ./RTWLib_Tests/resources/. ${{ github.workspace }}/RTWLib_Tests/bin/Debug/netcoreapp8.0/resources/
+        run: cp -r ./RTWLib_Tests/resources/. ${{ github.workspace }}/RTWLib_Tests/bin/Debug/net8.0/resources/
 
       - name: List build output
-        run: ls -R '${{github.workspace}}/RTWLib_Tests/bin/Debug/netcoreapp8.0'
+        run: ls -R '${{github.workspace}}/RTWLib_Tests/bin/Debug/net8.0'
 
       - name: Log files
         run: ls

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -38,10 +38,10 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Copy Resources
-      run: cp -r ./RTWLib_Tests/resources ./RTWLib_Tests/bin/Debug/netcoreapp8.0/resources
+      run: cp -r ./RTWLib_Tests/resources ./RTWLib_Tests/bin/Debug/net8.0/resources
 
     - name: Log files
-      run: ls ./RTWLib_Tests/bin/Debug/netcoreapp8.0/
+      run: ls ./RTWLib_Tests/bin/Debug/net8.0/
 
     - name: Restore packages
       run: dotnet restore ./RTWLib_CLI/RTWLib_CLI.csproj

--- a/RTWLibPlus/RTWLibPlus.csproj
+++ b/RTWLibPlus/RTWLibPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType Condition="'$(Configuration)' == 'Debug'">portable</DebugType>
     <DebugType Condition="'$(Configuration)' != 'Debug'">none</DebugType>
   </PropertyGroup>

--- a/RTWLib_CLI/RTWLib_CLI.csproj
+++ b/RTWLib_CLI/RTWLib_CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>RTW-CLI-Randomiser</AssemblyName>
     <Copyright>Copyright © 2023</Copyright>
     <!-- x-release-please-start-version -->

--- a/RTWLib_Tests/RTWLib_Tests.csproj
+++ b/RTWLib_Tests/RTWLib_Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)